### PR TITLE
 chore: Remove inaccurate syntax comment from AS files

### DIFF
--- a/tests/tests/swfs/avm1/issue_2084/Column.as
+++ b/tests/tests/swfs/avm1/issue_2084/Column.as
@@ -1,5 +1,3 @@
-// vim:syntax=javascript
-
 class Column extends MovieClip
 {
     function attachIcon(n : Number, initObject : Object) {

--- a/tests/tests/swfs/avm1/issue_2084/Main.as
+++ b/tests/tests/swfs/avm1/issue_2084/Main.as
@@ -1,5 +1,3 @@
-// vim:syntax=javascript
-
 class Main extends MovieClip {
 
     var first : Boolean;


### PR DESCRIPTION
No functional changes. I didn't bother recompiling the SWF files since just the comments were removed. Just addresses a small pet peeve of mine where these files were appearing in this search: https://github.com/search?q=repo%3Aruffle-rs%2Fruffle++language%3AJavaScript&type=code