### PR TITLE
chore: Properly detect files as GLSL on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,10 @@
 # Set *.as files as ActionScript, vs. GitHub's guess of AngelScript
 *.as   linguist-language=ActionScript
 
+# Properly detect files as GLSL on Github
+*.frag			linguist-language=GLSL
+*.vert			linguist-language=GLSL
+
 # Binary files
 *.png  binary
 *.fla  binary


### PR DESCRIPTION
Right now it thinks .frag files are JavaScript: https://github.com/search?q=repo%3Aruffle-rs%2Fruffle++path%3A.frag&type=code. The .vert files are correctly highlighted (https://github.com/search?q=repo%3Aruffle-rs%2Fruffle++path%3A.vert&type=code), but it's still better to be explicit. I looked at some of these results on GitHub to match sure I use the right syntax for the .gitattributes file: https://github.com/search?q=*.frag+++linguist-language%3D&type=code